### PR TITLE
Disable Live View in BulbWnd if camera does not support it

### DIFF
--- a/CameraControl/windows/BulbWnd.xaml.cs
+++ b/CameraControl/windows/BulbWnd.xaml.cs
@@ -241,6 +241,7 @@ namespace CameraControl.windows
             _defaultScriptFile = Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), Settings.AppName,
                 "default.dccscript");
+            btn_astrolv.IsEnabled = CameraDevice.HaveLiveView;
             try
             {
                 if (File.Exists(_defaultScriptFile))


### PR DESCRIPTION
Disable the LiveView button in BlubWnd for cameras that do not support
the LiveView feature
