### PR TITLE
Migration to correct GetAdditionalLiveViewData

### DIFF
--- a/CameraControl.Devices/Nikon/NikonBase.cs
+++ b/CameraControl.Devices/Nikon/NikonBase.cs
@@ -1260,7 +1260,7 @@ namespace CameraControl.Devices.Nikon
                         return viewData;
                     }
                     int cbBytesRead = result.Data.Length;
-                    GetAditionalLIveViewData(viewData, result.Data);
+                    GetAdditionalLiveViewData(viewData, result.Data);
                     viewData.ImageDataPosition = 384;
                     viewData.ImageData = result.Data;
                 }
@@ -1273,7 +1273,13 @@ namespace CameraControl.Devices.Nikon
             return viewData;
         }
 
+        [Obsolete("Use GetAdditionalLiveViewData instead.", false)]
         protected virtual void GetAditionalLIveViewData(LiveViewData viewData, byte[] result)
+        {
+            GetAdditionalLiveViewData(viewData, result);
+        }
+
+        protected virtual void GetAdditionalLiveViewData(LiveViewData viewData, byte[] result)
         {
             viewData.LiveViewImageWidth = ToInt16(result, 0);
             viewData.LiveViewImageHeight = ToInt16(result, 2);

--- a/CameraControl.Devices/Nikon/NikonD3200.cs
+++ b/CameraControl.Devices/Nikon/NikonD3200.cs
@@ -78,7 +78,7 @@ namespace CameraControl.Devices.Nikon
             }
         }
 
-        protected override void GetAditionalLIveViewData(LiveViewData viewData, byte[] result)
+        protected override void GetAdditionalLiveViewData(LiveViewData viewData, byte[] result)
         {
             viewData.LiveViewImageWidth = ToInt16(result, 8);
             viewData.LiveViewImageHeight = ToInt16(result, 10);

--- a/CameraControl.Devices/Nikon/NikonD3X.cs
+++ b/CameraControl.Devices/Nikon/NikonD3X.cs
@@ -62,7 +62,7 @@ namespace CameraControl.Devices.Nikon
             if (result.Data == null || result.Data.Length <= headerSize)
                 return null;
             int cbBytesRead = result.Data.Length;
-            GetAditionalLIveViewData(viewData, result.Data);
+            GetAdditionalLiveViewData(viewData, result.Data);
 
             MemoryStream copy = new MemoryStream((int) cbBytesRead - headerSize);
             copy.Write(result.Data, headerSize, (int)cbBytesRead - headerSize);

--- a/CameraControl.Devices/Nikon/NikonD600.cs
+++ b/CameraControl.Devices/Nikon/NikonD600.cs
@@ -61,7 +61,7 @@ namespace CameraControl.Devices.Nikon
                     }
                     if (result.Data == null || result.Data.Length <= headerSize)
                         return null;
-                    GetAditionalLIveViewData(viewData, result.Data);
+                    GetAdditionalLiveViewData(viewData, result.Data);
                     viewData.ImageDataPosition = headerSize;
                     viewData.ImageData = result.Data;
                 }
@@ -73,7 +73,7 @@ namespace CameraControl.Devices.Nikon
             return viewData;
         }
 
-        protected override void GetAditionalLIveViewData(LiveViewData viewData, byte[] result)
+        protected override void GetAdditionalLiveViewData(LiveViewData viewData, byte[] result)
         {
             viewData.LiveViewImageWidth = ToInt16(result, 8);
             viewData.LiveViewImageHeight = ToInt16(result, 10);

--- a/CameraControl.Devices/Nikon/NikonD700.cs
+++ b/CameraControl.Devices/Nikon/NikonD700.cs
@@ -122,7 +122,7 @@ namespace CameraControl.Devices.Nikon
             if (result.Data == null || result.Data.Length <= headerSize)
                 return null;
             int cbBytesRead = result.Data.Length;
-            GetAditionalLIveViewData(viewData, result.Data);
+            GetAdditionalLiveViewData(viewData, result.Data);
 
             MemoryStream copy = new MemoryStream((int) cbBytesRead - headerSize);
             copy.Write(result.Data, headerSize, (int)cbBytesRead - headerSize);

--- a/CameraControl.Devices/Nikon/NikonD7100.cs
+++ b/CameraControl.Devices/Nikon/NikonD7100.cs
@@ -40,7 +40,7 @@ namespace CameraControl.Devices.Nikon
 {
     public class NikonD7100 : NikonD600
     {
-        protected override void GetAditionalLIveViewData(LiveViewData viewData, byte[] result)
+        protected override void GetAdditionalLiveViewData(LiveViewData viewData, byte[] result)
         {
             viewData.LiveViewImageWidth = ToInt16(result, 8);
             viewData.LiveViewImageHeight = ToInt16(result, 10);

--- a/CameraControl.Devices/Nikon/NikonD800.cs
+++ b/CameraControl.Devices/Nikon/NikonD800.cs
@@ -150,7 +150,7 @@ namespace CameraControl.Devices.Nikon
             SetProperty(CONST_CMD_SetDevicePropValue, new[] {(byte) 0}, CONST_PROP_ApplicationMode);
         }
 
-        protected override void GetAditionalLIveViewData(LiveViewData viewData, byte[] result)
+        protected override void GetAdditionalLiveViewData(LiveViewData viewData, byte[] result)
         {
             viewData.LiveViewImageWidth = ToInt16(result, 8);
             viewData.LiveViewImageHeight = ToInt16(result, 10);

--- a/CameraControl.Devices/Nikon/NikonD90.cs
+++ b/CameraControl.Devices/Nikon/NikonD90.cs
@@ -67,7 +67,7 @@ namespace CameraControl.Devices.Nikon
             if (result.Data == null || result.Data.Length <= headerSize)
                 return null;
             int cbBytesRead = result.Data.Length;
-            GetAditionalLIveViewData(viewData, result.Data);
+            GetAdditionalLiveViewData(viewData, result.Data);
 
             MemoryStream copy = new MemoryStream(cbBytesRead - headerSize);
             copy.Write(result.Data, headerSize, cbBytesRead - headerSize);


### PR DESCRIPTION
This corrects a typo that bugs me every time I see it, and remains backward-compatible, for now.