### PR TITLE
TransferFile can now write to supplied streams.

### DIFF
--- a/CameraControl.Devices/BaseCameraDevice.cs
+++ b/CameraControl.Devices/BaseCameraDevice.cs
@@ -427,6 +427,10 @@ namespace CameraControl.Devices
         {
         }
 
+        public virtual void TransferFile(object o, System.IO.Stream stream)
+        {
+        }
+
         public void OnCaptureCompleted(object sender, EventArgs args)
         {
             if (CaptureCompleted != null)

--- a/CameraControl.Devices/ICameraDevice.cs
+++ b/CameraControl.Devices/ICameraDevice.cs
@@ -140,6 +140,7 @@ namespace CameraControl.Devices
         void Close();
 
         void TransferFile(object o, string filename);
+        void TransferFile(object o, System.IO.Stream stream);
 
         /// <summary>
         /// Occurs when photo captured.


### PR DESCRIPTION
Added an additional method signature for `TransferFile` that accepts a
stream. This allows memory-to-memory transfers, without involving the
filesystem. The filename version of `TransferFile` now just wraps the stream
version. `BinaryWriter` is no longer used internally, as it was
unnecessary for writing a byte array, and closed the stream when in a
using block.

Also made retry count a constant to make it a bit more obvious to anyone who might be interested.

This change is backward-compatible.