### PR TITLE
Fix for Nikon D600 to make it using its own NikonD600 class derived f…

### DIFF
--- a/CameraControl.Devices/CameraDeviceManager.cs
+++ b/CameraControl.Devices/CameraDeviceManager.cs
@@ -150,7 +150,7 @@ namespace CameraControl.Devices
                                   {"D5000", typeof (NikonD90)},
                                   {"D60", typeof (NikonD60)},
                                   {"D610", typeof (NikonD600Base)},
-                                  {"D600", typeof (NikonD600Base)},
+                                  {"D600", typeof (NikonD600)},
                                   {"D70", typeof (NikonD40)},
                                   {"D70s", typeof (NikonD40)},
                                   {"D700", typeof (NikonD700)},


### PR DESCRIPTION
Nikon cameras (like D800) surely need a check if their class is derived from NikonD600base.
I see the schematic of inheritance has been changed and I don't know if the previous code (not good for D600) was working as expected by other cameras.