### PR TITLE
Update HidUsbRelay.cs

### DIFF
--- a/CameraControl.Plugins/ExternalDevices/HidUsbRelay.cs
+++ b/CameraControl.Plugins/ExternalDevices/HidUsbRelay.cs
@@ -65,6 +65,10 @@ namespace CameraControl.Plugins.ExternalDevices
 
         public bool CloseShutter(CustomConfig config)
         {
+            Connect();
+            RelayDeviceWrapper.usb_relay_device_close_all_relay_channel(Hd);
+            RelayDeviceWrapper.usb_relay_device_close(Hd);
+            Hd = 0;
             return true;
         }
 


### PR DESCRIPTION
Added code to close shutter when using HID USB Relay.  Currently, when this type of external shutter comes to the end of the desired open shutter time, the relay remains open indefinitely.  Looking at the code, it appears there was no function created to close the shutter.  I'm new to this coding language though, so I could be missing something.  Thanks for taking a look!

-Chris