### PR TITLE
Device properties names should contain no '.' character to be support…

### DIFF
--- a/CameraControl.Devices/Nikon/NikonBase.cs
+++ b/CameraControl.Devices/Nikon/NikonBase.cs
@@ -507,7 +507,7 @@ namespace CameraControl.Devices.Nikon
             AdvancedProperties.Add(InitStillCaptureMode());
             AdvancedProperties.Add(InitOnOffProperty("Auto Iso", 0xD054));
             AdvancedProperties.Add(InitFlash());
-            AdvancedProperties.Add(InitOnOffProperty("Long exp. NR", CONST_PROP_NoiseReduction));
+            AdvancedProperties.Add(InitOnOffProperty("Long exp NR", CONST_PROP_NoiseReduction));
             AdvancedProperties.Add(InitNRHiIso());
             AdvancedProperties.Add(InitExposureDelay());
             AdvancedProperties.Add(InitLock());

--- a/CameraControl.Devices/Nikon/NikonD5200.cs
+++ b/CameraControl.Devices/Nikon/NikonD5200.cs
@@ -32,6 +32,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using CameraControl.Devices.Classes;
 
 #endregion
 
@@ -39,5 +40,21 @@ namespace CameraControl.Devices.Nikon
 {
     public class NikonD5200 : NikonD600Base
     {
+        protected override PropertyValue<long> InitExposureDelay()
+        {
+
+            PropertyValue<long> res = new PropertyValue<long>()
+            {
+                Name = "Exposure delay mode",
+                IsEnabled = true,
+                Code = 0xD06A
+            };
+            res.AddValues("OFF", 0);
+            res.AddValues("1 sec", 1);
+            res.ReloadValues();
+            res.ValueChanged +=
+                (sender, key, val) => SetProperty(CONST_CMD_SetDevicePropValue, new[] { (byte)val }, res.Code);
+            return res;
+        }
     }
 }


### PR DESCRIPTION
…ed by CommandLineProcessor