### PR TITLE
Fixed a bug where objects larger than ~2.1GB would fail transfer

### DIFF
--- a/CameraControl.Devices/TransferProtocol/DDServer/DataBlockContainer.cs
+++ b/CameraControl.Devices/TransferProtocol/DDServer/DataBlockContainer.cs
@@ -20,7 +20,7 @@ namespace CameraControl.Devices.TransferProtocol.DDServer
             {
                 numBytes += payload.Read(Payload, numBytes, Header.PayloadLength - numBytes);
                 if (callback != null)
-                    callback(Header.PayloadLength, numBytes);
+                    callback((uint)Header.PayloadLength, (uint)numBytes);
             }
         }
 

--- a/CameraControl.Devices/TransferProtocol/PtpIp/EndDataPacket.cs
+++ b/CameraControl.Devices/TransferProtocol/PtpIp/EndDataPacket.cs
@@ -20,7 +20,7 @@ namespace CameraControl.Devices.TransferProtocol.PtpIp
                         (int) (Header.Length - 8 - 4 -
                                numBytes)); // payload.Read(Payload, numBytes, Header.PayloadLength - numBytes);
                 if (callback != null)
-                    callback((int) Header.Length, numBytes);
+                    callback(Header.Length, (uint)numBytes);
             }
 
         }
@@ -38,7 +38,7 @@ namespace CameraControl.Devices.TransferProtocol.PtpIp
                 outStream.Write(buff, 0, bytesRead);
                 numBytes += bytesRead;
                 if (callback != null)
-                    callback((int) Header.Length, numBytes);
+                    callback(Header.Length, (uint)numBytes);
             }
         }
 

--- a/PortableDeviceLib/StillImageDevice.cs
+++ b/PortableDeviceLib/StillImageDevice.cs
@@ -13,7 +13,7 @@ namespace PortableDeviceLib
 
     public class StillImageDevice : PortableDevice
     {
-        public delegate void TransferCallback(int total, int current);
+        public delegate void TransferCallback(uint total, uint current);
 
         public StillImageDevice(string deviceId)
             : base(deviceId)
@@ -227,7 +227,7 @@ namespace PortableDeviceLib
                 {
                 }
 
-                callback((int)tmpBufferSize, (int)offset);
+                callback(tmpBufferSize, offset);
 
                 GCHandle pinnedArray = GCHandle.Alloc(imgdate, GCHandleType.Pinned);
                 IntPtr ptr = pinnedArray.AddrOfPinnedObject();


### PR DESCRIPTION
The current offset and bytes read values are read as uint, then cast to int for progress update.
This cast to int overflows at INT_MAX to become negative. This negative number then is multiplied by 100 then cast back to uint which then overflows the uint.

Instead the transfer callback should just use uints.