### PR TITLE
fix for issue 313 

### DIFF
--- a/CameraControl.Devices.Example/Form1.cs
+++ b/CameraControl.Devices.Example/Form1.cs
@@ -63,6 +63,7 @@ namespace CameraControl.Devices.Example
                 }
                 cmb_cameras.DisplayMember = "DeviceName";
                 cmb_cameras.SelectedItem = DeviceManager.SelectedCameraDevice;
+                DeviceManager.SelectedCameraDevice.CaptureInSdRam = true;
                 // check if camera support live view
                 btn_liveview.Enabled = DeviceManager.SelectedCameraDevice.GetCapability(CapabilityEnum.LiveView);
                 cmb_cameras.EndUpdate();


### PR DESCRIPTION
resolves the issue of invalid status on starting liveview in CameraControl.Devices.Example app

the fix is to set CaptureInSdRam to true when initializing the camera