### PR TITLE
Always show Full Res image on LayoutBase view

### DIFF
--- a/CameraControl/Layouts/LayoutBase.cs
+++ b/CameraControl/Layouts/LayoutBase.cs
@@ -106,10 +106,7 @@ namespace CameraControl.Layouts
             }
             else
             {
-                if (LayoutViewModel.ZoomIndex>0)
-                {
-                    LoadFullRes();
-                }
+                LoadFullRes();
             }
         }
 


### PR DESCRIPTION
The default "fit" view looks obviously blurry on a high DPI screen, such as a 4K monitor. This makes it difficult to check things such as focus. When taking some test photos, I initially thought that the camera was out of focus. However, after zooming in and then zooming back out, the image sharpened up, and I realized that the camera was in focus. Right now, I have to manually zoom in and zoom out to see the full in-focus image. This diff contains one proposed solution -- to load the full-res image by default, rather than the low res image (I think it's the "Large Thumbnail").

I wanted to submit this change for early feedback, and start a discussion on what is the proper solution. IMO, there are four solutions:

1. **By default load the full res image**. Using my 16mp camera, there is no noticeable performance difference between loading the full-res image (zoomed to 60%) and the low-res image (zoom fit). Each one takes about 5 seconds to load, from when I press the camera shutter, to when the final image is visible on the screen. However, there is a chance that people with 60mp cameras might experience a performance hit. The performance issue might be mitigated by the fact that it first loads the low-res image, and then loads the high-res image in the background.
2. **Make this a configurable option** By default, load full res image. However, provide an option in the settings menu to disable this functionality. I imagine that this will only be needed by people with high-res cameras (>24mp).
3. **Smart Selection** Depending on the original image size and the screen resolution, decide automatically whether to load the full res or low-res image.
4. **Increase the resolution of the low res image** Right now, it looks like large thumb size is 1600px. This would need to be increased to at least 4k resolution size (2.5x larger). IMO, this is probably going to slow down the other views that use the thumbnail, so is probably not the best option.

Camera: Nikon DF - 16mp
Format: Compressed Raw
Screen Resolution: 4500x3000px (higher than 4k, which is 3800 pixels wide)

I'm also happy to test this change locally, but I haven't figured out how to compile the code in Visual Studio yet.

Default Fit (center crop of screen)
![image](https://user-images.githubusercontent.com/950674/117552739-2d380000-b002-11eb-92ee-39a7a4a16c03.png)

After zooming in to 60%, and then zooming back out to "fit"
![image](https://user-images.githubusercontent.com/950674/117552758-3c1eb280-b002-11eb-8d0d-f71349d5233b.png)
