### PR TITLE
Add Nikon Z fc Support

### DIFF
--- a/CameraControl.Devices/CameraDeviceManager.cs
+++ b/CameraControl.Devices/CameraDeviceManager.cs
@@ -198,6 +198,7 @@ namespace CameraControl.Devices
                 {"L830", typeof(NikonL830)},
                 {"L840", typeof(NikonL830)},
                 {"Z 50", typeof(NikonZ6)},
+                {"Z fc", typeof(NikonZ6)},
                 {"Z 5", typeof(NikonZ6)},
                 {"Z 6", typeof(NikonZ6)},
                 {"Z 6_2", typeof(NikonZ6)},


### PR DESCRIPTION
Added signature for Nikon Z fc. The app now recognized the camera correctly and allow tethering.