### PR TITLE
add camera shortcut for capturing without auto focus

### DIFF
--- a/CameraControl.Core/Classes/CameraProperty.cs
+++ b/CameraControl.Core/Classes/CameraProperty.cs
@@ -195,6 +195,7 @@ namespace CameraControl.Core.Classes
         private LiveviewSettings _liveviewSettings;
         private int _sortOrder;
         private WindowCommandItem _keyTrigger;
+        private WindowCommandItem _keyTriggerNoAF;
         private int _delay;
         private bool _liveViewInSecMonitor;
         private bool _saveLiveViewWindow;
@@ -239,7 +240,16 @@ namespace CameraControl.Core.Classes
             }
         }
 
-
+        public WindowCommandItem KeyTriggerNoAF
+        {
+          get { return _keyTriggerNoAF; }
+          set
+          {
+            _keyTriggerNoAF = value;
+            NotifyPropertyChanged("KeyTriggerNoAF");
+          }
+        }
+       
         public bool SaveLiveViewWindow
         {
             get { return _saveLiveViewWindow; }
@@ -259,6 +269,7 @@ namespace CameraControl.Core.Classes
             Counter = 0;
             LiveviewSettings = new LiveviewSettings();
             KeyTrigger = new WindowCommandItem();
+            KeyTriggerNoAF = new WindowCommandItem();
             SaveLiveViewWindow = true;
             WindowRect = new Rect();
         }

--- a/CameraControl.Core/Classes/TriggerClass.cs
+++ b/CameraControl.Core/Classes/TriggerClass.cs
@@ -148,6 +148,13 @@ namespace CameraControl.Core.Classes
                         CameraHelper.Capture(device);
                         lastDevice = device;
                     }
+                    if (property.KeyTriggerNoAF.KeyEnum != Key.None && property.KeyTriggerNoAF.Alt == e.isAltPressed &&
+                        property.KeyTriggerNoAF.Ctrl == e.isCtrlPressed &&
+                        property.KeyTriggerNoAF.KeyEnum == inputKey)
+                    {
+                      CameraHelper.CaptureNoAf(device);
+                      lastDevice = device;
+                    }
                 }
             }
             catch (Exception exception)

--- a/CameraControl.Core/Translation/TranslationStrings.cs
+++ b/CameraControl.Core/Translation/TranslationStrings.cs
@@ -717,5 +717,8 @@ namespace CameraControl.Core.Translation
 
         // 04/11/2018
         public static string LabelShowFocusControlBar = "Show Focus Control Bar";
-    }
+
+        // 11/10/2021
+        public static string LabelKeyboardTriggerNoAF = "Keyboard trigger no auto focus";
+}
 }

--- a/CameraControl/windows/CameraPropertyWnd.xaml
+++ b/CameraControl/windows/CameraPropertyWnd.xaml
@@ -92,7 +92,16 @@
                             <ComboBox SelectedItem="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=my:CameraPropertyWnd, AncestorLevel=1}, Path=CameraProperty.KeyTrigger.Key}" ItemsSource="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=my:CameraPropertyWnd, AncestorLevel=1}, Path=AvailableKeys}" Margin="2"/>
                         </StackPanel>
                     </Expander>
-
+                    <Expander HorizontalAlignment="Stretch" IsExpanded="False"  >
+                        <Expander.Header>
+                            <TextBlock Text="{T:TranslateExtension LabelKeyboardTriggerNoAF}" FontWeight="Bold"/>
+                        </Expander.Header>
+                        <StackPanel Orientation="Vertical" Margin="24,8,24,16">
+                            <CheckBox IsChecked="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=my:CameraPropertyWnd, AncestorLevel=1}, Path=CameraProperty.KeyTriggerNoAF.Alt}" Content="Alt" Margin="5"/>
+                            <CheckBox IsChecked="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=my:CameraPropertyWnd, AncestorLevel=1}, Path=CameraProperty.KeyTriggerNoAF.Ctrl}" Content="Ctrl" Margin="5"/>
+                            <ComboBox SelectedItem="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=my:CameraPropertyWnd, AncestorLevel=1}, Path=CameraProperty.KeyTriggerNoAF.Key}" ItemsSource="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=my:CameraPropertyWnd, AncestorLevel=1}, Path=AvailableKeys}" Margin="2"/>
+                        </StackPanel>
+                    </Expander>
                 </StackPanel>
             </materialDesign:Card>
         </ScrollViewer>


### PR DESCRIPTION
Nikon D3400 refuses to capture photos using camera-specific hotkey when live view is open with a message "Invalid status". 
this could be related to #313 
Camera takes photos when capturing without auto focus just fine, so maybe adding a keyboard shortcut could be an option.
There is a  workaround for this: assign a keyboard shortcut in app settings to "LiveViewCapture" and then select active camera using shortcuts "NextCamera" and "PrevCamera". Focusing a camera could also be done by assigning another shortcut to "LiveViewFocus" command.