### PR TITLE
fixed issue with pointer=0 check that failed in 64bit builds.

### DIFF
--- a/CameraControl.Devices/Canon/CanonSDKBase.cs
+++ b/CameraControl.Devices/Canon/CanonSDKBase.cs
@@ -763,7 +763,7 @@ namespace CameraControl.Devices.Canon
                                                       //  }),
                                                       CameraDevice = this,
                                                       FileName = "IMG0000.jpg",
-                                                      Handle =e.Pointer.ToInt32() != 0?(object) e.Pointer: e
+                                                      Handle = e.Pointer != IntPtr.Zero  ? (object) e.Pointer : e
                                                   };
 
                 EosFileImageEventArgs file = e as EosFileImageEventArgs;


### PR DESCRIPTION
Just a small fix to get the CameraControl.Devices.dll also working with 64bit builds