### PR TITLE
Fix typo in TclScriptManager class name.

### DIFF
--- a/CameraControl.Core/CameraControl.Core.csproj
+++ b/CameraControl.Core/CameraControl.Core.csproj
@@ -271,7 +271,7 @@
     <Compile Include="TclScripting\ConsoleRedirect.cs" />
     <Compile Include="TclScripting\DccCommand.cs" />
     <Compile Include="TclScripting\EchoCommand.cs" />
-    <Compile Include="TclScripting\TclScripManager.cs" />
+    <Compile Include="TclScripting\TclScriptManager.cs" />
     <Compile Include="Translation\TranslateConverter.cs" />
     <Compile Include="Translation\TranslateExtension.cs" />
     <Compile Include="Translation\TranslationLangDesc.cs" />

--- a/CameraControl.Core/TclScripting/TclScriptManager.cs
+++ b/CameraControl.Core/TclScripting/TclScriptManager.cs
@@ -6,7 +6,7 @@ using Eagle._Interfaces.Public;
 
 namespace CameraControl.Core.TclScripting
 {
-    public class TclScripManager : IDisposable
+    public class TclScriptManager : IDisposable
     {
         public event OutputEventHandler Output;
         public event OutputEventHandler Error;
@@ -14,7 +14,7 @@ namespace CameraControl.Core.TclScripting
         private Interpreter _interpreter = null;
 
         #region Public Constructors
-        public TclScripManager()
+        public TclScriptManager()
         {
         }
         #endregion
@@ -285,7 +285,7 @@ namespace CameraControl.Core.TclScripting
             if (disposed && Engine.IsThrowOnDisposed(_interpreter, false))
             {
                 throw new ObjectDisposedException(
-                    typeof(TclScripManager).Name);
+                    typeof(TclScriptManager).Name);
             }
         }
 
@@ -315,7 +315,7 @@ namespace CameraControl.Core.TclScripting
         #endregion
 
         #region Destructor
-        ~TclScripManager()
+        ~TclScriptManager()
         {
             Dispose(false);
         }

--- a/CameraControl/MainWindow.xaml.cs
+++ b/CameraControl/MainWindow.xaml.cs
@@ -368,7 +368,7 @@ namespace CameraControl
                 {
                     try
                     {
-                        var manager = new TclScripManager();
+                        var manager = new TclScriptManager();
                         manager.Execute(File.ReadAllText(scriptFile));
                     }
                     catch (Exception exception)

--- a/CameraControl/ViewModel/TimelapseViewModel.cs
+++ b/CameraControl/ViewModel/TimelapseViewModel.cs
@@ -814,7 +814,7 @@ namespace CameraControl.ViewModel
                         {
                             try
                             {
-                                var manager = new TclScripManager();
+                                var manager = new TclScriptManager();
                                 manager.Execute(File.ReadAllText(ServiceProvider.Settings.DefaultSession.TimeLapseSettings.ScriptFile));
                             }
                             catch (Exception exception)

--- a/CameraControl/windows/ScriptWnd.xaml.cs
+++ b/CameraControl/windows/ScriptWnd.xaml.cs
@@ -58,7 +58,7 @@ namespace CameraControl.windows
     /// </summary>
     public partial class ScriptWnd : IWindow, IToolPlugin
     {
-        private readonly TclScripManager _manager = new TclScripManager();
+        private readonly TclScriptManager _manager = new TclScriptManager();
 
         public string Id
         {


### PR DESCRIPTION
These changes fix a typo in the Tcl scripting class name, i.e. changing it from "TclScripManager" to "TclScriptManager".