### PR TITLE
Fix for Nikon Z6/Z7 focus mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3076,3 +3076,6 @@ _ReSharper.CameraControl.ServerTest
 /packages/*
 /.vs/*
 *.wixpdb
+/CameraControl.Devices/.vs/*
+/Canon.Eos.Framework/.vs/*
+/PortableDeviceLib/.vs/*

--- a/CameraControl.Devices/Nikon/NikonZ.cs
+++ b/CameraControl.Devices/Nikon/NikonZ.cs
@@ -1,0 +1,66 @@
+﻿using CameraControl.Devices.Classes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CameraControl.Devices.Nikon
+{
+    public class NikonZ : NikonD500
+    {
+        protected override void InitFocusMode()
+        {
+            try
+            {
+                Log.Debug("InitFocusMode 1");
+                DeviceReady();
+                NormalFocusMode = new PropertyValue<long>();
+                NormalFocusMode.Name = "FocusMode";
+                NormalFocusMode.Code = CONST_PROP_AFModeSelect;
+                NormalFocusMode.IsEnabled = true;
+                NormalFocusMode.AddValues("MF", 0);
+                NormalFocusMode.AddValues("AF-S", 0x8010);
+                NormalFocusMode.AddValues("AF-C", 0x8011);
+                NormalFocusMode.AddValues("AF-F", 0x8013);
+                NormalFocusMode.ReloadValues();
+                NormalFocusMode.ValueChanged += NormalFocusMode_ValueChanged;
+                FocusMode = NormalFocusMode;
+                FocusMode.IsEnabled = false; //FocusMode in NikonZ is supported only in LiveView
+                ReadDeviceProperties(NormalFocusMode.Code);
+                Log.Debug("InitFocusMode 2");
+                LiveViewFocusMode = new PropertyValue<long>();
+                LiveViewFocusMode.Name = "FocusMode";
+                LiveViewFocusMode.Code = CONST_PROP_AfModeAtLiveView;
+                LiveViewFocusMode.IsEnabled = true;
+                LiveViewFocusMode.AddValues("AF-S", 0);
+                LiveViewFocusMode.AddValues("AF-C", 1);
+                LiveViewFocusMode.AddValues("MF", 4);
+                LiveViewFocusMode.ReloadValues();
+                LiveViewFocusMode.ValueChanged += LiveViewFocusMode_ValueChanged;
+                ReadDeviceProperties(LiveViewFocusMode.Code);
+                Log.Debug("InitFocusMode 3");
+            }
+            catch (Exception exception)
+            {
+                Log.Error("Unable to init focus mode property", exception);
+            }
+        }
+
+        void LiveViewFocusMode_ValueChanged(object sender, string key, long val)
+        {
+            // CONST_PROP_AfModeAtLiveView accepts 1 single 8 bit value
+            byte[] val8bit = new byte[1];
+            val8bit[0] = (byte)val;
+
+            SetProperty(CONST_CMD_SetDevicePropValue, val8bit,CONST_PROP_AfModeAtLiveView);
+        }
+
+        private void NormalFocusMode_ValueChanged(object sender, string key, long val)
+        {
+            SetProperty(CONST_CMD_SetDevicePropValue, BitConverter.GetBytes((sbyte)val),
+                        CONST_PROP_AFModeSelect);
+        }
+
+    }
+}

--- a/CameraControl.Devices/Nikon/NikonZ6.cs
+++ b/CameraControl.Devices/Nikon/NikonZ6.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace CameraControl.Devices.Nikon
 {
-    public class NikonZ6 : NikonD500
+    public class NikonZ6 : NikonZ 
     {
         public const uint CONST_CMD_LiveViewZoomArea = 0xD1BD;
         public NikonZ6()

--- a/CameraControl.Devices/Nikon/NikonZ7.cs
+++ b/CameraControl.Devices/Nikon/NikonZ7.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace CameraControl.Devices.Nikon
 {
-    public class NikonZ7 : NikonD500
+    public class NikonZ7 : NikonZ
     {
         public NikonZ7()
         {
@@ -95,7 +95,7 @@ namespace CameraControl.Devices.Nikon
                 {37, "Hi 2"},
             };
         }
-        protected virtual void InitFNumber()
+        protected override void InitFNumber()
         {
             NormalFNumber = new PropertyValue<long> { IsEnabled = true, Name = "FNumber" };
             NormalFNumber.ValueChanged += NormalFNumber_ValueChanged;


### PR DESCRIPTION
Fixed parameters values for  CONST_PROP_AFModeSelect and CONST_PROP_AfModeAtLiveView  according to Nikon SDK docs. Tested only with a Nikon Z6.