### PR TITLE
Support for Nikon Z8

### DIFF
--- a/CameraControl.Devices/CameraDeviceManager.cs
+++ b/CameraControl.Devices/CameraDeviceManager.cs
@@ -206,6 +206,7 @@ namespace CameraControl.Devices
                 {"Z 6_2", typeof(NikonZ6)},
                 {"Z 7", typeof(NikonZ7)},
                 {"Z 7_2", typeof(NikonZ7)},
+                {"Z 8", typeof(NikonZ7)},
                 {"Z 9", typeof(NikonZ7)},
                 {"Z fc", typeof(NikonZ7)},
                 


### PR DESCRIPTION
Nikon Z8 has the same chip as Nikon Z9 and Nikon Z9 [uses](https://github.com/dukus/digiCamControl/blob/fd1acdb49ca25b8753cbc223731b42fca2896e58/CameraControl.Devices/CameraDeviceManager.cs#L209) NikonZ7 [control class](https://github.com/dukus/digiCamControl/blob/master/CameraControl.Devices/Nikon/NikonZ7.cs#L14). So I added Nikon Z8 like Z9. We have connected a Nikon Z8 and it was recognised without any issues.

I don't know do you manage assembly versions, so I didn't modified in any file.